### PR TITLE
Use safe buffer allocation methods

### DIFF
--- a/lib/mifare-classic.js
+++ b/lib/mifare-classic.js
@@ -47,7 +47,7 @@ function isTrailingBlock(blockNumber) {
 function getNdefData(rawTagData) {
 
     var messageLength = getNdefLength(rawTagData),    
-        buffer = new Buffer(rawTagData.length),  // could be messageLength + BLOCK_SIZE * 4
+        buffer = Buffer.alloc(rawTagData.length),  // could be messageLength + BLOCK_SIZE * 4
         sourceStart = 0,
         targetStart = 0,
         messageStart,

--- a/lib/ndef-util.js
+++ b/lib/ndef-util.js
@@ -6,7 +6,7 @@
 // https://github.com/chariotsolutions/phonegap-nfc/blob/master/www/phonegap-nfc.js
 
 function stringToBytes(string) {
-    var bytes = Buffer(string).toJSON();
+    var bytes = Buffer.from(string).toJSON();
     if (bytes.hasOwnProperty('data')) {
         // Node 0.12.x
         return bytes.data;
@@ -17,7 +17,7 @@ function stringToBytes(string) {
 }
 
 function bytesToString(bytes) {
-    return Buffer(bytes).toString();
+    return Buffer.from(bytes).toString();
 }
 
 // useful for readable version of Tag UID

--- a/lib/ndef.js
+++ b/lib/ndef.js
@@ -551,7 +551,7 @@ var stringifier = {
 
 // convert bytes to a String
 function s(bytes) {
-    return new Buffer(bytes).toString();
+    return Buffer.from(bytes).toString();
 }
 
 // expose helper objects


### PR DESCRIPTION
NodeJS has deprecated the Buffer(array) constructor, and recommends using Buffer.from() instead.
https://nodejs.org/fa/docs/guides/buffer-constructor-deprecation/